### PR TITLE
Fix error in matching by resetting index after sampling + test matching

### DIFF
--- a/CausalEstimate/core/effect_computation.py
+++ b/CausalEstimate/core/effect_computation.py
@@ -100,7 +100,7 @@ def compute_bootstrap_effects(
             ps_col,
             treatment_col,
             common_support_threshold,
-        )
+        ).reset_index(drop=True)
         # log_sample_stats(sample, treatment_col, outcome_col, ps_col)
         compute_effects_for_sample(
             estimators=estimators,

--- a/tests/test_interface/test_interface.py
+++ b/tests/test_interface/test_interface.py
@@ -333,6 +333,19 @@ class TestEstimator(unittest.TestCase):
         )
         self.assertIn("MATCHING", results)
 
+    def test_matching_bootstrap(self):
+        df = self.sample_data.copy()
+        df["treatment"] = np.random.binomial(1, 0.1, size=len(df))
+        estimator = Estimator(methods=["MATCHING"], effect_type="ATE")
+        results = estimator.compute_effect(
+            df,
+            treatment_col="treatment",
+            outcome_col="outcome",
+            ps_col="propensity_score",
+            bootstrap=True,
+            n_bootstraps=10,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fix bootstrap with matching and add a new test case for it.

Enhancements to bootstrap effects computation:

* [`CausalEstimate/core/effect_computation.py`](diffhunk://#diff-15249310d39f8dc6703255186092e0d5a1d216b8331f9e8de6e848962df68543L103-R103): Modified the `compute_bootstrap_effects` function to reset the index of the resulting DataFrame to ensure a clean index after computation. (`[CausalEstimate/core/effect_computation.pyL103-R103](diffhunk://#diff-15249310d39f8dc6703255186092e0d5a1d216b8331f9e8de6e848962df68543L103-R103)`)

New test case for bootstrap effects:

* [`tests/test_interface/test_interface.py`](diffhunk://#diff-99e513228acdf5287a905be981b539fbc5ffb541b5c8e51736542cbbde9be9cfR336-R348): Added a new test method `test_matching_bootstrap` to verify the functionality of the bootstrap effects computation. This test checks the computation of effects using the matching method with bootstrapping enabled. (`[tests/test_interface/test_interface.pyR336-R348](diffhunk://#diff-99e513228acdf5287a905be981b539fbc5ffb541b5c8e51736542cbbde9be9cfR336-R348)`)