### PR TITLE
Fix/stabilized weights

### DIFF
--- a/CausalEstimate/estimators/functional/ipw.py
+++ b/CausalEstimate/estimators/functional/ipw.py
@@ -182,9 +182,15 @@ def compute_ipw_weights(
         weight_treated = 1 / ps
         weight_control = 1 / (1 - ps)
         if clip_percentile < 1:
-            threshold = np.percentile(weight_treated, clip_percentile * 100)
+            treated_mask = A == 1
+            control_mask = A == 0
+            threshold = np.percentile(
+                weight_treated[treated_mask], clip_percentile * 100
+            )  # only compute threshold for treated group
             weight_treated = np.clip(weight_treated, a_min=None, a_max=threshold)
-            threshold = np.percentile(weight_control, clip_percentile * 100)
+            threshold = np.percentile(
+                weight_control[control_mask], clip_percentile * 100
+            )  # only compute threshold for control group
             weight_control = np.clip(weight_control, a_min=None, a_max=threshold)
         weights = np.where(A == 1, weight_treated, weight_control)
 

--- a/CausalEstimate/estimators/ipw.py
+++ b/CausalEstimate/estimators/ipw.py
@@ -18,6 +18,7 @@ class IPW(BaseEstimator):
         outcome_col="outcome",
         ps_col="ps",
         stabilized: bool = False,
+        clip_percentile: float = 1,
     ):
         """
         Inverse Probability Weighting estimator.
@@ -28,6 +29,7 @@ class IPW(BaseEstimator):
             outcome_col: Name of outcome column
             ps_col: Name of propensity score column
             stabilized: kep for backward compatibility
+            clip_percentile: percentile to clip the weights at
         """
         # Initialize base class with core parameters
         super().__init__(
@@ -36,6 +38,7 @@ class IPW(BaseEstimator):
             outcome_col=outcome_col,
             ps_col=ps_col,
         )
+        self.clip_percentile = clip_percentile
         if stabilized:
             warnings.warn("Stabilized weights are not used for IPW.", RuntimeWarning)
 
@@ -46,12 +49,16 @@ class IPW(BaseEstimator):
         )
 
         if self.effect_type in ["ATE", "ARR"]:
-            return compute_ipw_ate(A, Y, ps)
+            return compute_ipw_ate(A, Y, ps, clip_percentile=self.clip_percentile)
         elif self.effect_type == "ATT":
-            return compute_ipw_att(A, Y, ps)
+            return compute_ipw_att(A, Y, ps, clip_percentile=self.clip_percentile)
         elif self.effect_type == "RR":
-            return compute_ipw_risk_ratio(A, Y, ps)
+            return compute_ipw_risk_ratio(
+                A, Y, ps, clip_percentile=self.clip_percentile
+            )
         elif self.effect_type == "RRT":
-            return compute_ipw_risk_ratio_treated(A, Y, ps)
+            return compute_ipw_risk_ratio_treated(
+                A, Y, ps, clip_percentile=self.clip_percentile
+            )
         else:
             raise ValueError(f"Effect type '{self.effect_type}' is not supported.")

--- a/CausalEstimate/estimators/ipw.py
+++ b/CausalEstimate/estimators/ipw.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import warnings
 
 from CausalEstimate.estimators.base import BaseEstimator
 from CausalEstimate.estimators.functional.ipw import (
@@ -26,7 +27,7 @@ class IPW(BaseEstimator):
             treatment_col: Name of treatment column
             outcome_col: Name of outcome column
             ps_col: Name of propensity score column
-            stabilized: Whether to use stabilized weights
+            stabilized: kep for backward compatibility
         """
         # Initialize base class with core parameters
         super().__init__(
@@ -35,9 +36,8 @@ class IPW(BaseEstimator):
             outcome_col=outcome_col,
             ps_col=ps_col,
         )
-
-        # IPW-specific parameters
-        self.stabilized = stabilized
+        if stabilized:
+            warnings.warn("Stabilized weights are not used for IPW.", RuntimeWarning)
 
     def _compute_effect(self, df: pd.DataFrame) -> dict:
         """Calculate causal effect using IPW."""
@@ -46,12 +46,12 @@ class IPW(BaseEstimator):
         )
 
         if self.effect_type in ["ATE", "ARR"]:
-            return compute_ipw_ate(A, Y, ps, stabilized=self.stabilized)
+            return compute_ipw_ate(A, Y, ps)
         elif self.effect_type == "ATT":
-            return compute_ipw_att(A, Y, ps, stabilized=self.stabilized)
+            return compute_ipw_att(A, Y, ps)
         elif self.effect_type == "RR":
-            return compute_ipw_risk_ratio(A, Y, ps, stabilized=self.stabilized)
+            return compute_ipw_risk_ratio(A, Y, ps)
         elif self.effect_type == "RRT":
-            return compute_ipw_risk_ratio_treated(A, Y, ps, stabilized=self.stabilized)
+            return compute_ipw_risk_ratio_treated(A, Y, ps)
         else:
             raise ValueError(f"Effect type '{self.effect_type}' is not supported.")

--- a/tests/helpers/setup.py
+++ b/tests/helpers/setup.py
@@ -22,63 +22,88 @@ from CausalEstimate.utils.constants import (
 
 
 class TestEffectBase(unittest.TestCase):
-    n: int = 10000
-    alpha: List[float] = [0.1, 0.2, -0.3, 0]
-    beta: List[float] = [0.5, 0.8, -0.6, 0.3, 0]
-    seed: int = 42
+    """
+    Base class for testing causal effect estimators.
+
+    The TRUE data generating process (DGP) is controlled by the full `alpha` and
+    `beta` vectors. Child classes can override these to create different DGPs.
+
+    - alpha: [intercept, X1, X2, X1*X2 interaction]
+    - beta:  [intercept, A, X1, X2, X1*X2 interaction]
+
+    The predictions for ps, Y1_hat, and Y0_hat are generated from an *assumed model*
+    that only uses the main effects (the first 3 or 4 coefficients). This is done
+    intentionally, so that if a child class sets a non-zero interaction term in
+    `alpha` or `beta`, the model used for predictions becomes misspecified.
+    The default values are set to a correctly specified DGP.
+    """
+
+    n: int = 30_000
+    alpha: List[float] = [0.1, 0.2, -0.3]
+    beta: List[float] = [0.5, 0.8, -0.6, 0.3]
+    noise_level: float = 0  # logit
+    cutoff_epsilon: float = 1e-7
+    seed: int = 41
 
     @classmethod
     def setUpClass(cls):
         # Simulate realistic data for testing
         rng = np.random.default_rng(cls.seed)
-        # Covariates
+
+        # 1. Simulate data using the full coefficient vectors (the TRUE DGP).
+        #    Child classes override cls.alpha/cls.beta to change this DGP.
         data = simulate_binary_data(
             cls.n, alpha=cls.alpha, beta=cls.beta, seed=cls.seed
         )
 
-        # Predicted outcomes
-        X = data[["X1", "X2"]].values
+        X_raw = data[["X1", "X2"]].values
         A = data[TREATMENT_COL].values
         Y = data[OUTCOME_COL].values
-        ps = expit(
-            cls.alpha[0] + cls.alpha[1] * X[:, 0] + cls.alpha[2] * X[:, 1]
-        ) + 0.01 * rng.normal(size=cls.n)
+
+        # 2. Generate predictions using an ASSUMED model that only considers
+        #    main effects. This is where the misspecification is introduced.
+
+        # --- Propensity Score Model ---
+        # The assumed model for PS uses only the first 3 coefficients (intercept, X1, X2).
+        # If `cls.alpha` has a non-zero 4th element, this model is MISSPECIFIED.
+        ps_model_coeffs = np.array(cls.alpha[:3])
+        X_ps_design = np.column_stack(
+            [np.ones(cls.n), X_raw]
+        )  # Design matrix for main effects
+        ps = expit(X_ps_design @ ps_model_coeffs) + cls.noise_level * rng.normal(
+            size=cls.n
+        )
+
+        outcome_model_coeffs = np.array(cls.beta[:4])
+
+        # Design matrices for main effects outcome model
+        X_y1_design = np.column_stack([np.ones(cls.n), np.ones(cls.n), X_raw])  # A=1
+        X_y0_design = np.column_stack([np.ones(cls.n), np.zeros(cls.n), X_raw])  # A=0
+        X_y_obs_design = np.column_stack([np.ones(cls.n), A, X_raw])  # A=observed
+
+        # Generate predictions for Y1_hat, Y0_hat, and Yhat
         Y1_hat = expit(
-            cls.beta[0]
-            + cls.beta[1] * 1
-            + cls.beta[2] * X[:, 0]
-            + cls.beta[3] * X[:, 1]
-        ) + 0.01 * rng.normal(size=cls.n)
+            X_y1_design @ outcome_model_coeffs
+        ) + cls.noise_level * rng.normal(size=cls.n)
+
         Y0_hat = expit(
-            cls.beta[0] + cls.beta[2] * X[:, 0] + cls.beta[3] * X[:, 1]
-        ) + 0.01 * rng.normal(size=cls.n)
+            X_y0_design @ outcome_model_coeffs
+        ) + cls.noise_level * rng.normal(size=cls.n)
         Yhat = expit(
-            cls.beta[0]
-            + cls.beta[1] * A
-            + cls.beta[2] * X[:, 0]
-            + cls.beta[3] * X[:, 1]
-        ) + 0.01 * rng.normal(size=cls.n)
+            X_y_obs_design @ outcome_model_coeffs
+        ) + cls.noise_level * rng.normal(size=cls.n)
 
-        # clip
-        eps = 1e-6
-        Yhat = np.clip(Yhat, eps, 1 - eps)
-        Y1_hat = np.clip(Y1_hat, eps, 1 - eps)
-        Y0_hat = np.clip(Y0_hat, eps, 1 - eps)
-        ps = np.clip(ps, eps, 1 - eps)
+        # 3. Finalize data preparation
+        eps = cls.cutoff_epsilon
+        cls.A, cls.Y = A, Y
+        cls.ps = np.clip(ps, eps, 1 - eps)
+        cls.Y1_hat = np.clip(Y1_hat, eps, 1 - eps)
+        cls.Y0_hat = np.clip(Y0_hat, eps, 1 - eps)
+        cls.Yhat = np.clip(Yhat, eps, 1 - eps)
 
-        cls.A = A
-        cls.Y = Y
-        cls.ps = ps
-        cls.Y1_hat = Y1_hat
-        cls.Y0_hat = Y0_hat
-        cls.Yhat = Yhat
-
-        true_ate = compute_ATE_theoretical_from_data(data, beta=cls.beta)
-        true_att = compute_ATT_theoretical_from_data(data, beta=cls.beta)
-        true_rr = compute_RR_theoretical_from_data(data, beta=cls.beta)
-        cls.true_ate = true_ate
-        cls.true_att = true_att
-        cls.true_rr = true_rr
+        cls.true_ate = compute_ATE_theoretical_from_data(data, beta=cls.beta)
+        cls.true_att = compute_ATT_theoretical_from_data(data, beta=cls.beta)
+        cls.true_rr = compute_RR_theoretical_from_data(data, beta=cls.beta)
 
         # for classes that take dataframe as input
         cls.data = data

--- a/tests/test_functional/test_aipw.py
+++ b/tests/test_functional/test_aipw.py
@@ -24,15 +24,50 @@ class TestComputeAIPWATE(TestEffectBase):
 class TestAIPW_ATE_base(TestEffectBase):
     def test_compute_aipw_ate(self):
         ate_aipw = compute_aipw_ate(self.A, self.Y, self.ps, self.Y0_hat, self.Y1_hat)
+        self.assertAlmostEqual(ate_aipw[EFFECT], self.true_ate, delta=0.02)
+
+
+class TestAIPW_ATE_base_stabilized(TestEffectBase):
+    def test_compute_aipw_ate_stabilized(self):
+        ate_aipw = compute_aipw_ate(self.A, self.Y, self.ps, self.Y0_hat, self.Y1_hat)
         self.assertAlmostEqual(ate_aipw[EFFECT], self.true_ate, delta=0.03)
 
 
 class TestAIPW_ATE_ps_misspecified(TestAIPW_ATE_base):
     alpha = [0.1, 0.2, -0.3, 10]
 
+    def test_compute_aipw_ate(self):
+        ate_aipw = compute_aipw_ate(self.A, self.Y, self.ps, self.Y0_hat, self.Y1_hat)
+        self.assertNotAlmostEqual(ate_aipw[EFFECT], self.true_ate, delta=0.03)
+
 
 class TestAIPW_ATE_outcome_model_misspecified(TestAIPW_ATE_base):
-    beta = [0.5, 10, 0.6, 0.3, 10]
+    beta = [
+        0.5,
+        10,
+        0.6,
+        0.3,
+        10,
+    ]  # if the ps is correct, there is no adjustment, thus outcome model does not matter in this case.
+
+    def test_compute_aipw_ate(self):
+        ate_aipw = compute_aipw_ate(self.A, self.Y, self.ps, self.Y0_hat, self.Y1_hat)
+        self.assertAlmostEqual(ate_aipw[EFFECT], self.true_ate, delta=0.01)
+
+
+class TestAIPW_ATE_outcome_and_ps_model_misspecified(TestAIPW_ATE_base):
+    beta = [
+        0.5,
+        10,
+        0.6,
+        0.3,
+        10,
+    ]  # if the ps is correct, there is no adjustment, thus outcome model does not matter in this case.
+    alpha = [0.1, 0.2, -0.3, 10]
+
+    def test_compute_aipw_ate(self):
+        ate_aipw = compute_aipw_ate(self.A, self.Y, self.ps, self.Y0_hat, self.Y1_hat)
+        self.assertNotAlmostEqual(ate_aipw[EFFECT], self.true_ate, delta=0.05)
 
 
 class TestAIPW_ATT_base(TestEffectBase):
@@ -42,11 +77,31 @@ class TestAIPW_ATT_base(TestEffectBase):
 
 
 class TestAIPW_ATT_outcome_model_misspecified(TestAIPW_ATT_base):
-    beta = [0.5, 0.8, -0.6, 0.3, 5]
+    beta = [
+        0.5,
+        0.8,
+        -0.6,
+        0.3,
+        5,
+    ]  # if the ps is correct, there is no adjustment, thus outcome model does not matter in this case.
+
+    def test_compute_aipw_att(self):
+        att_aipw = compute_aipw_att(self.A, self.Y, self.ps, self.Y0_hat)
+        self.assertAlmostEqual(att_aipw[EFFECT], self.true_att, delta=0.01)
 
 
 class TestAIPW_ATT_ps_misspecified(TestAIPW_ATT_base):
-    alpha = [0.1, 0.2, -0.3, 1]
+    alpha = [
+        0.1,
+        0.2,
+        -0.3,
+        10,
+        5,
+    ]  # evem though the ps is misspecified, the adjustment gives as a correct effect
+
+    def test_compute_aipw_att(self):
+        att_aipw = compute_aipw_att(self.A, self.Y, self.ps, self.Y0_hat)
+        self.assertAlmostEqual(att_aipw[EFFECT], self.true_att, delta=0.01)
 
 
 class TestAIPW_ATT_PS_misspecified_and_OutcomeModel_misspecified(TestAIPW_ATT_base):

--- a/tests/test_functional/test_ipw.py
+++ b/tests/test_functional/test_ipw.py
@@ -34,12 +34,6 @@ class TestIPWSanityChecks(unittest.TestCase):
         self.assertIsInstance(ate[EFFECT], float)
         self.assertTrue(-1 <= ate[EFFECT] <= 1)
 
-    def test_ipw_ate_stabilized(self):
-        # This test now runs on data guaranteed to have both groups
-        ate_stabilized = compute_ipw_ate(self.A, self.Y, self.ps, stabilized=True)
-        self.assertIsInstance(ate_stabilized[EFFECT], float)
-        self.assertTrue(-1 <= ate_stabilized[EFFECT] <= 1)
-
     def test_ipw_att(self):
         att = compute_ipw_att(self.A, self.Y, self.ps)
         self.assertIsInstance(att[EFFECT], float)
@@ -73,13 +67,6 @@ class TestIPWEstimators(unittest.TestCase):
         ate = compute_ipw_ate(self.A, self.Y, self.ps)
         self.assertIsInstance(ate[EFFECT], float)
         self.assertTrue(-1 <= ate[EFFECT] <= 1)  # Check ATE is within reasonable range
-
-    def test_ipw_ate_stabilized(self):
-        ate_stabilized = compute_ipw_ate(self.A, self.Y, self.ps, stabilized=True)
-        self.assertIsInstance(ate_stabilized[EFFECT], float)
-        self.assertTrue(
-            -1 <= ate_stabilized[EFFECT] <= 1
-        )  # Check ATE with stabilized weights
 
     def test_ipw_att(self):
         att = compute_ipw_att(self.A, self.Y, self.ps)
@@ -139,10 +126,8 @@ class TestIPWWeightFunction(unittest.TestCase):
         cls.ps = np.array([0.8, 0.4, 0.5, 0.2])
         cls.pi = 0.5
 
-    def test_att_stabilized_weights(self):
-        weights = compute_ipw_weights(
-            self.A, self.ps, weight_type="ATT", stabilized=True
-        )
+    def test_att_weights(self):
+        weights = compute_ipw_weights(self.A, self.ps, weight_type="ATT")
         stabilization_factor = (1 - self.pi) / self.pi
         expected = np.array(
             [
@@ -167,12 +152,12 @@ class TestComputeIPW_base(TestEffectBase):
         self.assertAlmostEqual(ate_ipw[EFFECT], self.true_ate, delta=0.1)
 
 
-class TestComputeIPWATE_outcome_model_misspecified(TestComputeIPW_base):
-    beta = [0.5, 0.8, -0.6, 0.3, 3]
-
-
 class TestComputeIPWATE_ps_model_misspecified(TestComputeIPW_base):
     alpha = [0.1, 0.2, -0.3, 3]
+
+    def test_compute_ipw_ate(self):
+        ate_ipw = compute_ipw_ate(self.A, self.Y, self.ps)
+        self.assertNotAlmostEqual(ate_ipw[EFFECT], self.true_ate, delta=0.02)
 
 
 class TestComputeIPWATE_both_models_misspecified(TestComputeIPW_base):
@@ -181,7 +166,7 @@ class TestComputeIPWATE_both_models_misspecified(TestComputeIPW_base):
 
     def test_compute_ipw_ate(self):
         ate_ipw = compute_ipw_ate(self.A, self.Y, self.ps)
-        self.assertNotAlmostEqual(ate_ipw[EFFECT], self.true_ate, delta=0.05)
+        self.assertNotAlmostEqual(ate_ipw[EFFECT], self.true_ate, delta=0.1)
 
 
 class TestComputeIPW_ATT(TestEffectBase):
@@ -189,15 +174,7 @@ class TestComputeIPW_ATT(TestEffectBase):
 
     def test_compute_ipw_att(self):
         att_ipw = compute_ipw_att(self.A, self.Y, self.ps)
-        self.assertAlmostEqual(att_ipw[EFFECT], self.true_att, delta=0.1)
-
-
-class TestComputeIPW_ATT_stabilized(TestEffectBase):
-    """Checks if IPW can recover the true ATT in a well-behaved simulation."""
-
-    def test_compute_ipw_att(self):
-        att_ipw = compute_ipw_att(self.A, self.Y, self.ps, stabilized=True)
-        self.assertAlmostEqual(att_ipw[EFFECT], self.true_att, delta=0.1)
+        self.assertAlmostEqual(att_ipw[EFFECT], self.true_att, delta=0.01)
 
 
 class TestComputeIPW_RR(TestEffectBase):
@@ -205,15 +182,7 @@ class TestComputeIPW_RR(TestEffectBase):
 
     def test_compute_ipw_rr(self):
         rr_ipw = compute_ipw_risk_ratio(self.A, self.Y, self.ps)
-        self.assertAlmostEqual(rr_ipw[EFFECT], self.true_rr, delta=0.1)
-
-
-class TestComputeIPW_RR_stabilized(TestEffectBase):
-    """Checks if IPW can recover the true RR in a well-behaved simulation."""
-
-    def test_compute_ipw_rr(self):
-        rr_ipw = compute_ipw_risk_ratio(self.A, self.Y, self.ps, stabilized=True)
-        self.assertAlmostEqual(rr_ipw[EFFECT], self.true_rr, delta=0.2)
+        self.assertAlmostEqual(rr_ipw[EFFECT], self.true_rr, delta=0.01)
 
 
 # Run the unittests

--- a/tests/test_functional/test_ipw_clipping.py
+++ b/tests/test_functional/test_ipw_clipping.py
@@ -1,0 +1,174 @@
+import unittest
+from CausalEstimate.estimators.functional.ipw import (
+    compute_ipw_weights,
+    compute_ipw_ate,
+    compute_ipw_att,
+)
+import numpy as np
+from CausalEstimate.utils.constants import EFFECT
+
+
+class TestClipPercentileFunctionality(unittest.TestCase):
+    """
+    Tests for the clip_percentile functionality in IPW estimators.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        # Create data with extreme propensity scores to test clipping
+        rng = np.random.default_rng(42)
+        n = 100
+        cls.A = rng.choice([0, 1], size=n, p=[0.6, 0.4])
+        cls.Y = rng.binomial(1, 0.3 + 0.2 * cls.A)
+
+        # Create propensity scores with some extreme values
+        cls.ps_extreme = np.concatenate(
+            [
+                rng.uniform(
+                    0.01, 0.05, size=10
+                ),  # Very low ps (high weights for controls)
+                rng.uniform(0.2, 0.8, size=80),  # Normal ps
+                rng.uniform(
+                    0.95, 0.99, size=10
+                ),  # Very high ps (high weights for treated)
+            ]
+        )
+        rng.shuffle(cls.ps_extreme)
+
+    def test_ate_weight_clipping_reduces_extreme_weights(self):
+        """Test that clipping reduces extreme weights for ATE estimation."""
+        # Compute weights without clipping
+        weights_unclipped = compute_ipw_weights(
+            self.A, self.ps_extreme, weight_type="ATE", clip_percentile=1.0
+        )
+
+        # Compute weights with clipping at 90th percentile
+        weights_clipped = compute_ipw_weights(
+            self.A, self.ps_extreme, weight_type="ATE", clip_percentile=0.9
+        )
+
+        # Check that maximum weight is reduced after clipping
+        self.assertLess(weights_clipped.max(), weights_unclipped.max())
+
+        # Check that 90th percentile is respected
+        treated_mask = self.A == 1
+        control_mask = self.A == 0
+
+        if treated_mask.sum() > 0:
+            treated_weights_unclipped = weights_unclipped[treated_mask]
+            treated_weights_clipped = weights_clipped[treated_mask]
+            threshold_treated = np.percentile(treated_weights_unclipped, 90)
+            self.assertTrue(np.all(treated_weights_clipped <= threshold_treated))
+
+        if control_mask.sum() > 0:
+            control_weights_unclipped = weights_unclipped[control_mask]
+            control_weights_clipped = weights_clipped[control_mask]
+            threshold_control = np.percentile(control_weights_unclipped, 90)
+            self.assertTrue(np.all(control_weights_clipped <= threshold_control))
+
+    def test_att_weight_clipping_only_affects_controls(self):
+        """Test that clipping for ATT only affects control group weights."""
+        # Compute weights without clipping
+        weights_unclipped = compute_ipw_weights(
+            self.A, self.ps_extreme, weight_type="ATT", clip_percentile=1.0
+        )
+
+        # Compute weights with clipping at 80th percentile
+        weights_clipped = compute_ipw_weights(
+            self.A, self.ps_extreme, weight_type="ATT", clip_percentile=0.8
+        )
+
+        treated_mask = self.A == 1
+        control_mask = self.A == 0
+
+        # Treated weights should remain unchanged (always 1.0)
+        if treated_mask.sum() > 0:
+            np.testing.assert_array_equal(
+                weights_unclipped[treated_mask], weights_clipped[treated_mask]
+            )
+            self.assertTrue(np.all(weights_clipped[treated_mask] == 1.0))
+
+        # Control weights should be clipped
+        if control_mask.sum() > 0:
+            control_weights_unclipped = weights_unclipped[control_mask]
+            control_weights_clipped = weights_clipped[control_mask]
+            threshold = np.percentile(control_weights_unclipped, 80)
+            self.assertTrue(np.all(control_weights_clipped <= threshold))
+
+    def test_clip_percentile_effect_on_ate_estimation(self):
+        """Test that clipping affects ATE estimates by reducing influence of extreme weights."""
+        # Estimate ATE without clipping
+        ate_unclipped = compute_ipw_ate(
+            self.A, self.Y, self.ps_extreme, clip_percentile=1.0
+        )
+
+        # Estimate ATE with clipping
+        ate_clipped = compute_ipw_ate(
+            self.A, self.Y, self.ps_extreme, clip_percentile=0.9
+        )
+
+        # The estimates should be different (clipping should reduce variance)
+        self.assertNotEqual(ate_unclipped[EFFECT], ate_clipped[EFFECT])
+
+        # Both should still be reasonable values
+        self.assertTrue(-1 <= ate_clipped[EFFECT] <= 1)
+        self.assertTrue(-1 <= ate_unclipped[EFFECT] <= 1)
+
+    def test_clip_percentile_effect_on_att_estimation(self):
+        """Test that clipping affects ATT estimates."""
+        # Estimate ATT without clipping
+        att_unclipped = compute_ipw_att(
+            self.A, self.Y, self.ps_extreme, clip_percentile=1.0
+        )
+
+        # Estimate ATT with clipping
+        att_clipped = compute_ipw_att(
+            self.A, self.Y, self.ps_extreme, clip_percentile=0.85
+        )
+
+        # The estimates should be different
+        self.assertNotEqual(att_unclipped[EFFECT], att_clipped[EFFECT])
+
+        # Both should still be reasonable values
+        self.assertTrue(-1 <= att_clipped[EFFECT] <= 1)
+        self.assertTrue(-1 <= att_unclipped[EFFECT] <= 1)
+
+    def test_no_clipping_when_percentile_is_one(self):
+        """Test that no clipping occurs when clip_percentile=1.0."""
+        weights_no_clip_1 = compute_ipw_weights(
+            self.A, self.ps_extreme, weight_type="ATE", clip_percentile=1.0
+        )
+        weights_no_clip_2 = compute_ipw_weights(
+            self.A, self.ps_extreme, weight_type="ATE", clip_percentile=1.0
+        )
+
+        # Should be identical
+        np.testing.assert_array_equal(weights_no_clip_1, weights_no_clip_2)
+
+        # Should equal the unclipped theoretical weights
+        expected_weights = np.where(
+            self.A == 1, 1 / self.ps_extreme, 1 / (1 - self.ps_extreme)
+        )
+        np.testing.assert_array_almost_equal(weights_no_clip_1, expected_weights)
+
+    def test_extreme_clipping_percentiles(self):
+        """Test behavior with very low clip percentiles."""
+        # Test with very aggressive clipping (50th percentile)
+        weights_aggressive = compute_ipw_weights(
+            self.A, self.ps_extreme, weight_type="ATE", clip_percentile=0.5
+        )
+
+        # All weights should be reasonable (not extremely large)
+        self.assertTrue(np.all(weights_aggressive > 0))
+        self.assertTrue(np.all(weights_aggressive < 100))  # Reasonable upper bound
+
+        # Test that it doesn't crash with very small percentiles
+        weights_very_aggressive = compute_ipw_weights(
+            self.A, self.ps_extreme, weight_type="ATE", clip_percentile=0.1
+        )
+        self.assertTrue(np.all(weights_very_aggressive > 0))
+
+
+# Run the unittests
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_functional/test_tmle/test_basic.py
+++ b/tests/test_functional/test_tmle/test_basic.py
@@ -47,6 +47,28 @@ class TestTMLE_ATE_base(TestEffectBase):
         self.assertAlmostEqual(ate_tmle[EFFECT], self.true_ate, delta=0.02)
 
 
+class TestTMLE_ATE_base2(TestEffectBase):
+    alpha = [1, -0.2, -0.3]
+    beta = [0.1, 0.4, 0.6, -2]
+
+    def test_compute_tmle_ate(self):
+        ate_tmle = compute_tmle_ate(
+            self.A, self.Y, self.ps, self.Y0_hat, self.Y1_hat, self.Yhat
+        )
+        self.assertAlmostEqual(ate_tmle[EFFECT], self.true_ate, delta=0.02)
+
+
+class TestTMLE_ATE_base3(TestEffectBase):
+    alpha = [-1, 2, -0.3]
+    beta = [-1, 0.4, 0.6, -2]
+
+    def test_compute_tmle_ate(self):
+        ate_tmle = compute_tmle_ate(
+            self.A, self.Y, self.ps, self.Y0_hat, self.Y1_hat, self.Yhat
+        )
+        self.assertAlmostEqual(ate_tmle[EFFECT], self.true_ate, delta=0.02)
+
+
 class TestTMLE_RR(TestEffectBase):
     def test_compute_tmle_rr(self):
         rr_tmle = compute_tmle_rr(

--- a/tests/test_functional/test_tmle/test_fluctuation.py
+++ b/tests/test_functional/test_tmle/test_fluctuation.py
@@ -3,18 +3,13 @@ import unittest
 import numpy as np
 
 from CausalEstimate.estimators.functional.tmle import (
-    compute_tmle_ate,
-    compute_tmle_rr,
     estimate_fluctuation_parameter,
 )
-from CausalEstimate.estimators.functional.tmle_att import (
-    compute_tmle_att,
-)
+
 from CausalEstimate.estimators.functional.utils import (
     compute_clever_covariate_ate,
     compute_clever_covariate_att,
 )
-from CausalEstimate.utils.constants import EFFECT
 from tests.helpers.setup import TestEffectBase
 
 
@@ -37,39 +32,6 @@ class TestTMLE_ATT_Functions(TestEffectBase):
         epsilon = estimate_fluctuation_parameter(H, self.Y, self.Yhat)
         self.assertIsInstance(epsilon, float)
         self.assertTrue(np.isfinite(epsilon))
-
-
-class TestTMLE_ATE_base(TestEffectBase):
-    def test_compute_tmle_ate(self):
-        ate_tmle = compute_tmle_ate(
-            self.A, self.Y, self.ps, self.Y0_hat, self.Y1_hat, self.Yhat
-        )
-        self.assertAlmostEqual(ate_tmle[EFFECT], self.true_ate, delta=0.02)
-
-
-class TestTMLE_RR(TestEffectBase):
-    def test_compute_tmle_rr(self):
-        rr_tmle = compute_tmle_rr(
-            self.A, self.Y, self.ps, self.Y0_hat, self.Y1_hat, self.Yhat
-        )
-        self.assertAlmostEqual(rr_tmle[EFFECT], self.true_rr, delta=1)
-
-
-class TestTMLE_ATT(TestEffectBase):
-    def test_compute_tmle_att(self):
-        att_tmle = compute_tmle_att(
-            self.A, self.Y, self.ps, self.Y0_hat, self.Y1_hat, self.Yhat
-        )
-        self.assertAlmostEqual(att_tmle[EFFECT], self.true_att, delta=0.02)
-
-
-class TestTMLE_ATT_bounded(TestEffectBase):
-    def test_att_is_bounded(self):
-        att_tmle = compute_tmle_att(
-            self.A, self.Y, self.ps, self.Y0_hat, self.Y1_hat, self.Yhat
-        )
-        self.assertLessEqual(att_tmle[EFFECT], 1)
-        self.assertGreaterEqual(att_tmle[EFFECT], -1)
 
 
 if __name__ == "__main__":

--- a/tests/test_functional/test_tmle/test_misspecification.py
+++ b/tests/test_functional/test_tmle/test_misspecification.py
@@ -23,12 +23,24 @@ class TestTMLE_ATE_base(TestEffectBase):
 class TestTMLE_PS_misspecified(TestTMLE_ATE_base):
     alpha = [0.1, 0.2, -0.3, 3]
 
+    def test_compute_tmle_ate(self):
+        ate_tmle = compute_tmle_ate(
+            self.A, self.Y, self.ps, self.Y0_hat, self.Y1_hat, self.Yhat
+        )
+        self.assertAlmostEqual(ate_tmle[EFFECT], self.true_ate, delta=0.02)
 
-class TestTMLE_OutcomeModel_misspecified(TestTMLE_ATE_base):
+
+class TestTMLE_OutcomeModel_misspecified(TestEffectBase):
     beta = [0.5, 0.8, -0.6, 0.3, 3]
 
+    def test_compute_tmle_ate(self):
+        ate_tmle = compute_tmle_ate(
+            self.A, self.Y, self.ps, self.Y0_hat, self.Y1_hat, self.Yhat
+        )
+        self.assertAlmostEqual(ate_tmle[EFFECT], self.true_ate, delta=0.02)
 
-class TestTMLE_PS_misspecified_and_OutcomeModel_misspecified(TestTMLE_ATE_base):
+
+class TestTMLE_PS_misspecified_and_OutcomeModel_misspecified(TestEffectBase):
     alpha = [0.1, 0.2, -0.3, 5]
     beta = [0.5, 0.8, -0.6, 0.3, 5]
 
@@ -48,12 +60,24 @@ class TestTMLE_RR(TestEffectBase):
         self.assertAlmostEqual(rr_tmle[EFFECT], self.true_rr, delta=1)
 
 
-class TestTMLE_RR_PS_misspecified(TestTMLE_RR):
+class TestTMLE_RR_PS_misspecified(TestEffectBase):
     alpha = [0.1, 0.2, -0.3, 5]
 
+    def test_compute_tmle_rr(self):
+        rr_tmle = compute_tmle_rr(
+            self.A, self.Y, self.ps, self.Y0_hat, self.Y1_hat, self.Yhat
+        )
+        self.assertAlmostEqual(rr_tmle[EFFECT], self.true_rr, delta=1)
 
-class TestTMLE_RR_OutcomeModel_misspecified(TestTMLE_RR):
+
+class TestTMLE_RR_OutcomeModel_misspecified(TestEffectBase):
     beta = [0.5, 0.8, -0.6, 0.3, 5]
+
+    def test_compute_tmle_rr(self):
+        rr_tmle = compute_tmle_rr(
+            self.A, self.Y, self.ps, self.Y0_hat, self.Y1_hat, self.Yhat
+        )
+        self.assertAlmostEqual(rr_tmle[EFFECT], self.true_rr, delta=1)
 
 
 class TestTMLE_RR_PS_misspecified_and_OutcomeModel_misspecified(TestEffectBase):
@@ -77,11 +101,23 @@ class TestTMLE_ATT(TestEffectBase):
 
 
 class TestTMLE_ATT_PS_misspecified(TestTMLE_ATT):
-    alpha = [0.1, 0.2, -0.3, 5]
+    alpha = [0.1, 0.2, -0.3, 10]  #  the adjustment gives as a correct effect
+
+    def test_compute_tmle_att(self):
+        att_tmle = compute_tmle_att(
+            self.A, self.Y, self.ps, self.Y0_hat, self.Y1_hat, self.Yhat
+        )
+        self.assertAlmostEqual(att_tmle[EFFECT], self.true_att, delta=0.01)
 
 
 class TestTMLE_ATT_OutcomeModel_misspecified(TestTMLE_ATT):
-    beta = [0.9, 0.8, -0.6, 0.3, 5, 1]
+    beta = [0.9, 0.8, -0.6, 0.3, 5, 1]  #  the adjustment gives as a correct effect
+
+    def test_compute_tmle_att(self):
+        att_tmle = compute_tmle_att(
+            self.A, self.Y, self.ps, self.Y0_hat, self.Y1_hat, self.Yhat
+        )
+        self.assertAlmostEqual(att_tmle[EFFECT], self.true_att, delta=0.01)
 
 
 class TestTMLE_ATT_PS_misspecified_and_OutcomeModel_misspecified(TestTMLE_ATT):
@@ -93,7 +129,7 @@ class TestTMLE_ATT_PS_misspecified_and_OutcomeModel_misspecified(TestTMLE_ATT):
         att_tmle = compute_tmle_att(
             self.A, self.Y, self.ps, self.Y0_hat, self.Y1_hat, self.Yhat
         )
-        self.assertNotAlmostEqual(att_tmle[EFFECT], self.true_att, delta=0.1)
+        self.assertNotAlmostEqual(att_tmle[EFFECT], self.true_att, delta=0.05)
 
 
 if __name__ == "__main__":

--- a/tests/test_functional/test_tmle/test_stabilization.py
+++ b/tests/test_functional/test_tmle/test_stabilization.py
@@ -1,5 +1,4 @@
 import unittest
-from typing import List
 
 import numpy as np
 
@@ -47,84 +46,6 @@ class TestTMLE_ATT_stabilized(TestEffectBase):
             stabilized=True,
         )
         self.assertAlmostEqual(att_tmle[EFFECT], self.true_att, delta=0.02)
-
-
-class TestTMLEStabilizationBenefit(TestEffectBase):
-    """
-    Demonstrates that stabilization reduces variance for the TMLE estimator
-    by bootstrapping from a single, high-variance data simulation.
-    """
-
-    # Override alpha from TestEffectBase to create a high-variance scenario
-    alpha: List[float] = [0.5, -2.5, 3.0, 0]
-    # Use a larger sample for a more stable bootstrap base
-    n: int = 5000
-
-    def _get_bootstrap_standard_error(
-        self, n_replicates: int, stabilized: bool
-    ) -> float:
-        """
-        Calculates the standard error of the TMLE ATE estimate via bootstrap.
-        It relies on the full data created by TestEffectBase.setUpClass.
-        """
-        rng = np.random.default_rng(self.seed)
-        n_obs = len(self.A)
-        bootstrap_ates = []
-
-        for _ in range(n_replicates):
-            # Create a bootstrap sample by drawing indices with replacement
-            indices = rng.choice(n_obs, size=n_obs, replace=True)
-
-            # Resample all necessary arrays for TMLE
-            A_boot = self.A[indices]
-            Y_boot = self.Y[indices]
-            ps_boot = self.ps[indices]
-            Y0_hat_boot = self.Y0_hat[indices]
-            Y1_hat_boot = self.Y1_hat[indices]
-            Yhat_boot = self.Yhat[indices]
-
-            # Calculate the ATE on the resampled data using the actual TMLE function
-            ate_boot = compute_tmle_ate(
-                A_boot,
-                Y_boot,
-                ps_boot,
-                Y0_hat_boot,
-                Y1_hat_boot,
-                Yhat_boot,
-                stabilized=stabilized,
-            )
-
-            if not np.isnan(ate_boot[EFFECT]):
-                bootstrap_ates.append(ate_boot[EFFECT])
-
-        # The standard deviation of the bootstrap estimates is our standard error
-        return np.std(bootstrap_ates)
-
-    def test_stabilization_reduces_bootstrap_variance(self):
-        """
-        Asserts that the bootstrap standard error is smaller for the stabilized TMLE estimator.
-        """
-        n_replicates = 100  # Keep lower for speed, increase for precision
-
-        # --- Estimate Standard Error for both estimators ---
-        se_unstabilized = self._get_bootstrap_standard_error(
-            n_replicates=n_replicates, stabilized=False
-        )
-        se_stabilized = self._get_bootstrap_standard_error(
-            n_replicates=n_replicates, stabilized=True
-        )
-
-        print(
-            f"\n[TMLE Stabilization Benefit] Unstabilized ATE SE: {se_unstabilized:.4f}"
-        )
-        print(f"[TMLE Stabilization Benefit] Stabilized ATE SE:   {se_stabilized:.4f}")
-
-        # --- The Definitive Assertion ---
-        self.assertLess(
-            se_stabilized,
-            se_unstabilized,
-            "Stabilized TMLE should yield a lower bootstrap standard error, indicating reduced variance.",
-        )
 
 
 class TestTMLEStabilizedVsUnstabilized(TestEffectBase):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added percentile-based clipping for inverse-propensity weighting (clip_percentile) to control extreme weights.

- Refactor
  - Simplified IPW behavior: stabilization flag is ignored (warning emitted); per-group masking returns NaN for empty groups.

- Documentation
  - Updated docs to describe clipping-based workflow and deprecate stabilization usage.

- Tests
  - Expanded misspecification coverage; added IPW clipping tests and new TMLE ATE scenarios; removed several stabilized-weight and fluctuation tests; tightened tolerances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->